### PR TITLE
feat: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT="3.10-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/wasmtime_wasi.sh \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/python-3
+{
+	"name": "Dev",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "3.10-bullseye",
+			// Options
+			"NODE_VERSION": "16"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.defaultInterpreterPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor",
+		"matklad.rust-analyzer",
+		"tamasfe.even-better-toml",
+		"serayuzgur.crates"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/library-scripts/finalize.sh",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"rust": "latest"
+	}
+}

--- a/.devcontainer/library-scripts/finalize.sh
+++ b/.devcontainer/library-scripts/finalize.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+printf "Running 'postCreateCommand' Script\n"
+
+# Install Rust Targets
+printf "Installing Rust Targets\n"
+rustup update stable --no-self-update
+rustup default stable
+rustup target add wasm32-unknown-unknown
+rustup target add wasm32-wasi
+
+# A code size profiler for wasm
+cargo install twiggy cargo-wasi cargo-expand
+# wit-bindgen-cli
+cargo install --git https://github.com/bytecodealliance/wit-bindgen wit-bindgen-cli
+
+# Install Python stuff
+printf "Installing Python Dependencies"
+pip install mypy wasmtime

--- a/.devcontainer/library-scripts/wasmtime_wasi.sh
+++ b/.devcontainer/library-scripts/wasmtime_wasi.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+WASMTIME_VERSION=0.37.0
+
+# wasmtime
+curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz | \
+    tar -xJ --wildcards --no-anchored --strip-components 1 -C /usr/bin wasmtime
+
+# wasi-sdk
+cd /opt && curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz |
+    tar -xz
+echo 'alias clang=/opt/wasi-sdk-16.0/bin/clang' >>/etc/bash.bashrc
+echo 'alias clang++=/opt/wasi-sdk-16.0/bin/clang++' >>/etc/bash.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian as builder
+
+RUN apt-get clean
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    curl
+
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Get Python
+RUN apt-get install python3 -y
+RUN apt-get install python3-pip -y
+RUN pip install wasmtime 
+
+COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/wasmtime_wasi.sh \
+    && bash /tmp/library-scripts/finalize.sh \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts


### PR DESCRIPTION
This PR introduces two Dockerfiles that use shared library-scripts. The key difference is that one sets up a vscode user and uses VS Code the features utility.

Eventually, we'll want to introduce the versions used as ARGS but I want to go ahead and land this first. The plan for that would be to support the .devcontainer.json VS Code args field (plain old docker args) and pass those docker args to the library-scripts much like the upstream [devcontainer repo](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library). 
