### PR TITLE
fix: dockerfile and example fixes

### DIFF
--- a/docker/Dockerfile-shell
+++ b/docker/Dockerfile-shell
@@ -10,10 +10,9 @@ ARG UID=499
 ARG GID=499
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update                                                             \
-    && apt-get install -y --no-install-recommends git lldb gdb curl clang      \
-    && apt-get install -y --no-install-recommends xz-utils sudo make vim pip   \
-    && apt-get install -y --no-install-recommends mariadb-client pkg-config    \
-    && apt-get install -y --no-install-recommends openssl libssl-dev           \
+    && apt-get install -y --no-install-recommends                              \
+        git lldb gdb curl clang xz-utils sudo make vim pip mariadb-client      \
+        pkg-config openssl libssl-dev libxml2-dev                              \
     && apt-get clean && rm -rf /var/lib/apt/lists/*                            \
     && pip --no-cache-dir install wasmtime                                     \
     \
@@ -31,9 +30,9 @@ RUN bash /tmp/library-scripts/install-wasmtime.sh
 #
 USER ${UID}:${GID}
 WORKDIR /home/${USER}
+ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
 
 # Install the Rust toolchain, targets, useful components, tools, and wit-bindgen.
-# Make sure to clean up the cargo cache when we're done.
 #
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y    \
     && $HOME/.cargo/bin/rustup target add wasm32-wasi wasm32-unknown-unknown   \
@@ -50,7 +49,7 @@ RUN bash /tmp/library-scripts/install-wit-bindgen.sh
 RUN git clone --depth 1 https://github.com/singlestore-labs/pushwasm.git       \
     && mkdir -p bin                                                            \
     && cd pushwasm                                                             \
-    && $HOME/.cargo/bin/cargo build --release                                  \
+    && cargo build --release                                                   \
     && cp target/release/pushwasm ../bin                                       \
     && cd ..                                                                   \
     && rm -rf pushwasm                                                         \
@@ -61,7 +60,7 @@ RUN git clone --depth 1 https://github.com/singlestore-labs/pushwasm.git       \
     && ln -s ../writ/bin/writ writ                                             \
     && cd ..                                                                   \
     \
-    && $HOME/.cargo/bin/cargo cache -r all
+    && cargo cache -r all
 
 # Hacks and stuff.
 #

--- a/docker/install-wit-bindgen.sh
+++ b/docker/install-wit-bindgen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # wit-bindgen is not stable. This pins to a last-known-good
-WIT_BINDGEN_REVISION="60e3c5b41e616fee239304d92128e117dd9be0a7#60e3c5b4"
+WIT_BINDGEN_REVISION="60e3c5b41e616fee239304d92128e117dd9be0a7"
 
 cargo install                                                           \
         --git https://github.com/bytecodealliance/wit-bindgen \

--- a/examples/cpp/power/Makefile
+++ b/examples/cpp/power/Makefile
@@ -1,10 +1,9 @@
 all: power.wasm
 
 power.wasm:
-	clang     						    \
+	clang    			    \
 	    --target=wasm32-unknown-wasi    \
 	    -mexec-model=reactor            \
-	    -s                              \
 	    -I.                             \
 	    -o power.wasm                   \
 	    power.c

--- a/examples/cpp/split/Makefile
+++ b/examples/cpp/split/Makefile
@@ -2,10 +2,10 @@ all: split.wasm
 
 split.wasm:
 	clang++                             \
+	    -g                              \
 	    -fno-exceptions                 \
 	    --target=wasm32-unknown-wasi    \
 	    -mexec-model=reactor            \
-	    -s                              \
 	    -I.                             \
 	    -o split.wasm                   \
 	    split.cpp

--- a/examples/cpp/split/split.cpp
+++ b/examples/cpp/split/split.cpp
@@ -1,41 +1,34 @@
 #include <memory>
+#include <split.h>
 #include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <vector>
-#include <split.h>
 
-__attribute__((weak, export_name("canonical_abi_realloc")))
-void *canonical_abi_realloc(
-void *ptr,
-size_t orig_size,
-size_t org_align,
-size_t new_size
-) {
+__attribute__((weak, export_name("canonical_abi_realloc"))) void *
+canonical_abi_realloc(void *ptr, size_t orig_size, size_t org_align,
+                      size_t new_size) {
   void *ret = realloc(ptr, new_size);
   if (!ret)
-  abort();
+    abort();
   return ret;
 }
 
-__attribute__((weak, export_name("canonical_abi_free")))
-void canonical_abi_free(
-void *ptr,
-size_t size,
-size_t align
-) {
+__attribute__((weak, export_name("canonical_abi_free"))) void
+canonical_abi_free(void *ptr, size_t size, size_t align) {
   free(ptr);
 }
 #include <string.h>
 
 void split_string_set(split_string_t *ret, const char *s) {
-  ret->ptr = (char*) s;
+  ret->ptr = (char *)s;
   ret->len = strlen(s);
 }
 
 void split_string_dup(split_string_t *ret, const char *s) {
   ret->len = strlen(s);
-  ret->ptr = reinterpret_cast<char *>(canonical_abi_realloc(NULL, 0, 1, ret->len));
+  ret->ptr =
+      reinterpret_cast<char *>(canonical_abi_realloc(NULL, 0, 1, ret->len));
   memcpy(ret->ptr, s, ret->len);
 }
 
@@ -53,75 +46,69 @@ void split_list_subphrase_free(split_list_subphrase_t *ptr) {
   }
   canonical_abi_free(ptr->ptr, ptr->len * 12, 4);
 }
-static int64_t RET_AREA[2];
-__attribute__((export_name("split-str")))
-int32_t __wasm_export_split_split_str(int32_t arg, int32_t arg0, int32_t arg1, int32_t arg2) {
-  split_string_t arg3 = (split_string_t) { (char*)(arg), (size_t)(arg0) };
-  split_string_t arg4 = (split_string_t) { (char*)(arg1), (size_t)(arg2) };
+
+__attribute__((aligned(4))) static uint8_t RET_AREA[8];
+__attribute__((export_name("split-str"))) int32_t
+__wasm_export_split_split_str(int32_t arg, int32_t arg0, int32_t arg1,
+                              int32_t arg2) {
+  split_string_t arg3 = (split_string_t){(char *)(arg), (size_t)(arg0)};
+  split_string_t arg4 = (split_string_t){(char *)(arg1), (size_t)(arg2)};
   split_list_subphrase_t ret;
   split_split_str(&arg3, &arg4, &ret);
-  int32_t ptr = (int32_t) &RET_AREA;
-  *((int32_t*)(ptr + 8)) = (int32_t) (ret).len;
-  *((int32_t*)(ptr + 0)) = (int32_t) (ret).ptr;
+  int32_t ptr = (int32_t)&RET_AREA;
+  *((int32_t *)(ptr + 4)) = (int32_t)(ret).len;
+  *((int32_t *)(ptr + 0)) = (int32_t)(ret).ptr;
   return ptr;
 }
 
+void split_split_str(split_string_t *phrase, split_string_t *delim,
+                     split_list_subphrase_t *ret0) {
+  // Clear the result.
+  memset(ret0, 0, sizeof(split_list_subphrase_t));
 
-void split_split_str(split_string_t *phrase, split_string_t *delim, split_list_subphrase_t *ret0)
-{
-    // Clear the result.
-    memset(ret0, 0, sizeof(split_list_subphrase_t));
-
-    // Parse the tokens.
-    std::string phr(phrase->ptr, phrase->len);
-    std::string dlm(delim->ptr, delim->len);
-    std::string tok;
-    std::vector<std::pair<std::string, size_t>> subs;
-    size_t start = 0, end = 0;
-    if (delim->len)
-    {
-        while ((end = phr.find(dlm, start)) != std::string::npos)
-        {
-            tok = phr.substr(start, end - start);
-            subs.push_back(std::pair<std::string, size_t>(tok, start));
-            start = end + dlm.length();
-        }
+  // Parse the tokens.
+  std::string phr(phrase->ptr, phrase->len);
+  std::string dlm(delim->ptr, delim->len);
+  std::string tok;
+  std::vector<std::pair<std::string, size_t>> subs;
+  size_t start = 0, end = 0;
+  if (delim->len) {
+    while ((end = phr.find(dlm, start)) != std::string::npos) {
+      tok = phr.substr(start, end - start);
+      subs.push_back(std::pair<std::string, size_t>(tok, start));
+      start = end + dlm.length();
     }
-    subs.push_back(std::pair<std::string, size_t>(phr.substr(start), start));
-    
-    // Populate the result.
-    bool err = false;
-    auto res = (split_subphrase_t *) malloc(phr.size() * sizeof(split_subphrase_t));
-    for (int i = 0; !err && i < subs.size(); ++i)
-    {
-        auto& sub = subs[i].first;
-        res[i].idx = static_cast<int32_t>(subs[i].second);
-        res[i].str.len = sub.length();
-        res[i].str.ptr = strdup(sub.c_str());
-        if (!res[i].str.ptr)
-            err = true;
-    }
+  }
+  subs.push_back(std::pair<std::string, size_t>(phr.substr(start), start));
 
-    // If success, assign the result.  Else, clean up and return an empty list.
-    if (!err)
-    {
-        // Success; assign the result.
-        ret0->ptr = res;
-        ret0->len = subs.size();
-    }
-    else
-    {
-        if (res)
-        {
-            for (int i = 0; i < subs.size(); ++i)
-                if (res[i].str.ptr)
-                    free(res[i].str.ptr);
-            free(res);
-        }
-    } 
+  // Populate the result.
+  bool err = false;
+  auto res =
+      (split_subphrase_t *)malloc(phr.size() * sizeof(split_subphrase_t));
+  for (int i = 0; !err && i < subs.size(); ++i) {
+    auto &sub = subs[i].first;
+    res[i].idx = static_cast<int32_t>(subs[i].second);
+    res[i].str.len = sub.length();
+    res[i].str.ptr = strdup(sub.c_str());
+    if (!res[i].str.ptr)
+      err = true;
+  }
 
-    // Per the Canonical ABI contract, free the input pointers.
-    free(phrase->ptr);
-    free(delim->ptr);
+  // If success, assign the result.  Else, clean up and return an empty list.
+  if (!err) {
+    // Success; assign the result.
+    ret0->ptr = res;
+    ret0->len = subs.size();
+  } else {
+    if (res) {
+      for (int i = 0; i < subs.size(); ++i)
+        if (res[i].str.ptr)
+          free(res[i].str.ptr);
+      free(res);
+    }
+  }
+
+  // Per the Canonical ABI contract, free the input pointers.
+  free(phrase->ptr);
+  free(delim->ptr);
 }
-


### PR DESCRIPTION
- Set PATH to include Rust tools in standalone shell
- In `install-wit-bindgen.sh`, the `WIT_BINDGEN_REVISION` had a `#...`
suffix at the end, which was causing the `cargo install` command to fail
- Removed the `-s` option from example CPP Makefiles so that symbols don't get stripped out
- Regenerated the `split` CPP example since the Canonical ABI changed since it was originally created.