### PR TITLE
ci: add github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+defaults:
+  run:
+    shell: bash
+
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        mode: [debug, release]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        components: rustfmt, clippy
+    
+    - name: Install wasm32-unknown-unknown target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Install wasm32-wasi target
+      run: rustup target add wasm32-wasi
+
+    - if : matrix.os == 'ubuntu-latest'
+      run: |
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz -L | tar xzvf -
+        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-16.0" >> $GITHUB_ENV
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax  
+    - run: pip install mypy wasmtime
+
+    - uses: actions/checkout@v3
+      with:
+        repository: 'singlestore-labs/writ'
+    - run: |
+        echo "$GITHUB_WORKSPACE/writ/bin" >> $GITHUB_ENV
+
+    - if: matrix.mode == 'release'
+      name: Test cpp-release build
+      run: make cpp-release
+      # paths: '**.cpp'
+
+    - if: matrix.mode == 'debug'
+      name: Test cpp-debug build
+      run: make cpp-debug
+      # paths: '**.cpp'
+
+    - if: matrix.mode == 'release'
+      name: Test rust-release build
+      run: make rust-release
+      # paths: '**.rust'
+
+    - if: matrix.mode == 'debug'
+      name: Test rust-debug build
+      run: make rust-debug
+      # paths: '**.rust'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-defaults:
-  run:
-    shell: bash
 
-# Cancel any in-flight jobs for the same PR/branch so there's only one active
-# at a time
+# Cancel any in-flight jobs for the same PR/branch so there's only one active at a time
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,11 +14,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        mode: [debug, release]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
@@ -38,45 +30,31 @@ jobs:
     - name: Install cargo-wasi
       run: cargo install cargo-wasi
 
-    - if : matrix.os == 'ubuntu-latest'
-      run: |
-        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz -L | tar xzvf -
-        echo "`pwd`/wasi-sdk-16.0/bin" >> $GITHUB_PATH
+    - run: |
+        curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz -L | tar xzvf - -C $GITHUB_WORKSPACE/
+        echo "$GITHUB_WORKSPACE/wasi-sdk-16.0/bin" >> $GITHUB_PATH
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax  
+        python-version: '3.x'
     - run: pip install mypy wasmtime
 
-    # TODO install writ
-    # - uses: actions/checkout@v3
-    #   # if: ${{ env.SECRETS_AVAILABLE == 'true' }}
-    #   with:
-    #     token: '${{ secrets.GITHUB_TOKEN }}'
-    #     repository: 'singlestore-labs/writ'
-    # - run: |
-    #     echo "$GITHUB_WORKSPACE/writ/bin" >> $GITHUB_PATH
-
-    - if: matrix.mode == 'release'
-      name: Test cpp-release build
+    - name: Test cpp-release build
       run: echo "$PATH" && make cpp-release
       working-directory: ./examples
       # paths: '**.cpp'
 
-    - if: matrix.mode == 'debug'
-      name: Test cpp-debug build
+    - name: Test cpp-debug build
       run: make cpp-debug
       working-directory: ./examples
       # paths: '**.cpp'
 
-    - if: matrix.mode == 'release'
-      name: Test rust-release build
+    - name: Test rust-release build
       run: make rust-release
       working-directory: ./examples
       # paths: '**.rust'
 
-    - if: matrix.mode == 'debug'
-      name: Test rust-debug build
+    - name: Test rust-debug build
       run: make rust-debug
       working-directory: ./examples
       # paths: '**.rust'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,39 +35,48 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Install wasm32-wasi target
       run: rustup target add wasm32-wasi
+    - name: Install cargo-wasi
+      run: cargo install cargo-wasi
 
     - if : matrix.os == 'ubuntu-latest'
       run: |
         curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-16/wasi-sdk-16.0-linux.tar.gz -L | tar xzvf -
-        echo "WASI_SDK_PATH=`pwd`/wasi-sdk-16.0" >> $GITHUB_ENV
+        echo "`pwd`/wasi-sdk-16.0/bin" >> $GITHUB_PATH
 
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax  
     - run: pip install mypy wasmtime
 
-    - uses: actions/checkout@v3
-      with:
-        repository: 'singlestore-labs/writ'
-    - run: |
-        echo "$GITHUB_WORKSPACE/writ/bin" >> $GITHUB_ENV
+    # TODO install writ
+    # - uses: actions/checkout@v3
+    #   # if: ${{ env.SECRETS_AVAILABLE == 'true' }}
+    #   with:
+    #     token: '${{ secrets.GITHUB_TOKEN }}'
+    #     repository: 'singlestore-labs/writ'
+    # - run: |
+    #     echo "$GITHUB_WORKSPACE/writ/bin" >> $GITHUB_PATH
 
     - if: matrix.mode == 'release'
       name: Test cpp-release build
-      run: make cpp-release
+      run: echo "$PATH" && make cpp-release
+      working-directory: ./examples
       # paths: '**.cpp'
 
     - if: matrix.mode == 'debug'
       name: Test cpp-debug build
       run: make cpp-debug
+      working-directory: ./examples
       # paths: '**.cpp'
 
     - if: matrix.mode == 'release'
       name: Test rust-release build
       run: make rust-release
+      working-directory: ./examples
       # paths: '**.rust'
 
     - if: matrix.mode == 'debug'
       name: Test rust-debug build
       run: make rust-debug
+      working-directory: ./examples
       # paths: '**.rust'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,6 +2,8 @@ name: GitHub pages
 
 on:
   push:
+    paths:
+      - '**.md'
     branches:
       - main
   pull_request:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -63,4 +63,3 @@ rust-clean:
 	    echo "Cleaning Rust example '`basename $$D`'..." ; \
 		make -C $$D clean ; \
 	done
-


### PR DESCRIPTION
This change runs the make build scripts for rust and cpp examples. Because we've seen some awkward differences between release and debug, this runs these in a matrix.

I have the paths commented out to get an e2e build and will add them back in a follow-up commit. Note that this does not yet run make test (missing writ).

Tested locally with https://github.com/nektos/act

```bash
act push -j test
```