### PR TITLE
Add example which defines some PostGIS functions

### DIFF
--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -38,3 +38,8 @@ Use the Faker library to generate some fake user profiles.
 
 [code with remote debugging instrumentation](./usergenerator-remote-debug)
 
+### Geo
+
+Provides some missing geospatial functions as UDFs, replicating the equivalent PostGIS functions. Uses the *geo* and *wkt* crates.
+
+[code](./geo/)

--- a/examples/rust/geo/Cargo.toml
+++ b/examples/rust/geo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "geo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "60e3c5b41e616fee239304d92128e117dd9be0a7" }
+geo = "0.22"
+wkt = "0.10"
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/geo/Makefile
+++ b/examples/rust/geo/Makefile
@@ -1,0 +1,82 @@
+MODULE := geo
+
+.PHONY: debug
+debug: $(eval TGT:=debug)
+debug: wasm
+
+.PHONY: release
+release: $(eval TGT:=release)
+release: RELFLAGS = --release
+release: wasm
+
+.PHONY: wasm
+wasm:
+	cargo wasi build --lib $(RELFLAGS)
+
+.PHONY: test
+test: debug
+	writ \
+	    -e "POLYGON((1 0,1 1,0 1,0 0,1 0))" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-convexhull \
+            "POLYGON((1 0,1 1,0 1,0 0,1 0))"
+	@echo PASS
+	writ \
+	    -e "POINT(0.5 0.5)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-centroid \
+            "POLYGON((1 0,1 1,0 1,0 0,1 0))"
+	@echo PASS
+	writ \
+	    -e "POINT(1 1)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-centroid \
+            "LINESTRING(0 0,1 1,2 2)"
+	@echo PASS
+	writ \
+	    -e "POINT(1 1)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-pointn \
+            "LINESTRING(0 0,1 1,2 2)" "1"
+	@echo PASS
+	writ \
+	    -e "POINT(2 2)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-pointn \
+            "LINESTRING(0 0,1 1,2 2)" "-1"
+	@echo PASS
+	writ \
+	    -e "POINT(1 0.5)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-closestpoint \
+            "POLYGON((0 0,0 1,1 1,1 0,0 0))" "POINT(2 0.5)"
+	@echo PASS
+	writ \
+	    -e "POINT(1 0.5)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-closestpoint \
+            "LINESTRING(0 0,0 1,1 1,1 0,0 0)" "POINT(0.6 0.5)"
+	@echo PASS
+	writ \
+	    -e "POLYGON((0 0,0 1,1 1,1 0,0 0))" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-envelope \
+            "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+	@echo PASS
+	writ \
+	    -e "true" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-intersects \
+            "POLYGON((0 0,0 1,1 1,1 0,0 0))" "POINT(0 0)"
+	@echo PASS
+	writ \
+	    -e "false" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-intersects \
+            "POLYGON((0 0,0 1,1 1,1 0,0 0))" "POINT(2 0)"
+	@echo PASS
+	writ \
+	    -e "POINT(1 0)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-translate \
+            "POINT(0 0)" "1" "0"
+	@echo PASS
+	writ \
+	    -e "POINT(0.5403023058681398 0.8414709848078965)" \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm st-rotate \
+            "POINT(1 0)" "1" "POINT(0 0)"
+	@echo PASS
+
+.PHONY: clean
+clean:
+	@cargo clean
+

--- a/examples/rust/geo/geo.wit
+++ b/examples/rust/geo/geo.wit
@@ -1,0 +1,9 @@
+st-convexhull: func(geo: string) -> string
+st-centroid: func(geo: string) -> string
+st-pointn: func(geo: string, index: s64) -> string
+st-closestpoint: func(geo: string, point: string) -> string
+st-envelope: func(geo: string) -> string
+st-intersects: func(geo1: string, geo2: string) -> bool
+st-translate: func(geo: string, dx: float64, dy: float64) -> string
+st-rotate: func(geo: string, rads: float64, point: string) -> string
+st-frechetdistance: func(geo1: string, geo2: string) -> float64

--- a/examples/rust/geo/src/lib.rs
+++ b/examples/rust/geo/src/lib.rs
@@ -1,0 +1,118 @@
+use std::f64::NAN;
+
+use ::geo::{
+    BoundingRect, Centroid, Closest, ClosestPoint, ConvexHull, CoordsIter, FrechetDistance,
+    Geometry, Intersects, Point, RotatePoint, Translate,
+};
+use wkt::{ToWkt, TryFromWkt};
+
+wit_bindgen_rust::export!("geo.wit");
+
+struct Geo;
+
+impl crate::geo::Geo for Geo {
+    fn st_convexhull(geo: String) -> String {
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(Geometry::Polygon(poly)) => poly.convex_hull().wkt_string(),
+            Some(Geometry::LineString(string)) => string.convex_hull().wkt_string(),
+            Some(Geometry::MultiPoint(points)) => points.convex_hull().wkt_string(),
+            None => "Invalid geometry".to_owned(),
+            _ => "Geometry doesn't support convex hull".to_owned(),
+        }
+    }
+
+    fn st_centroid(geo: String) -> String {
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(geo) => geo
+                .centroid()
+                .map(|point| point.wkt_string())
+                .unwrap_or("Geometry doesn't support centroid".to_owned()),
+            None => "Invalid geometry".to_owned(),
+        }
+    }
+
+    fn st_pointn(geo: String, index: i64) -> String {
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(Geometry::LineString(string)) => {
+                let coords = string
+                    .coords()
+                    .nth(index.rem_euclid(string.coords_count() as i64) as usize)
+                    .unwrap();
+                Point::new(coords.x, coords.y).wkt_string()
+            }
+            None => "Invalid geometry".to_owned(),
+            _ => "Geometry doesn't support point n".to_owned(),
+        }
+    }
+
+    fn st_closestpoint(geo: String, point: String) -> String {
+        let point = if let Ok(point) = Point::try_from_wkt_str(&point) {
+            point
+        } else {
+            return "Invalid point".to_owned();
+        };
+
+        match Geometry::<f64>::try_from_wkt_str(&geo)
+            .ok()
+            .map(|geo| geo.closest_point(&point))
+        {
+            Some(Closest::SinglePoint(point) | Closest::Intersection(point)) => point.wkt_string(),
+            Some(Closest::Indeterminate) => "Indeterminate".to_owned(),
+            None => "Invalid geometry".to_owned(),
+        }
+    }
+
+    fn st_envelope(geo: String) -> String {
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(geo) => geo
+                .bounding_rect()
+                .map(|rect| rect.wkt_string())
+                .unwrap_or("Geometry doesn't support envelope".to_owned()),
+            None => "Invalid geometry".to_owned(),
+        }
+    }
+
+    fn st_intersects(geo1: String, geo2: String) -> bool {
+        match (
+            Geometry::<f64>::try_from_wkt_str(&geo1),
+            Geometry::<f64>::try_from_wkt_str(&geo2),
+        ) {
+            (Ok(geo1), Ok(geo2)) => geo1.intersects(&geo2),
+            _ => false,
+        }
+    }
+
+    fn st_translate(geo: String, dx: f64, dy: f64) -> String {
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(geo) => geo.translate(dx, dy).wkt_string(),
+            None => "Invalid geometry".to_owned(),
+        }
+    }
+
+    fn st_rotate(geo: String, rads: f64, point: String) -> String {
+        let point = if let Ok(point) = Point::try_from_wkt_str(&point) {
+            point
+        } else {
+            return "Invalid point".to_owned();
+        };
+
+        match Geometry::<f64>::try_from_wkt_str(&geo).ok() {
+            Some(geo) => geo
+                .rotate_around_point(rads.to_degrees(), point)
+                .wkt_string(),
+            None => "Invalid geometry".to_owned(),
+        }
+    }
+
+    fn st_frechetdistance(geo1: String, geo2: String) -> f64 {
+        match (
+            Geometry::<f64>::try_from_wkt_str(&geo1),
+            Geometry::<f64>::try_from_wkt_str(&geo2),
+        ) {
+            (Ok(Geometry::LineString(string1)), Ok(Geometry::LineString(string2))) => {
+                string1.frechet_distance(&string2)
+            }
+            _ => NAN,
+        }
+    }
+}


### PR DESCRIPTION
This was my hackathon project:
- Add the following functions to a new example (rust/geo):
  - ST_ConvexHull
  - ST_Centroid
  - ST_PointN
  - ST_ClosestPoint
  - ST_Envelope
  - ST_Intersects
  - ST_Translate
  - ST_Rotate
  - ST_FrechetDistance 

The functions are implemented using the crates _geo_ and _wkt_.
Some functionality (for example, [ST_Buffer](https://github.com/georust/geo/issues/641), which was requested) is missing since _geo_ didn't support it out of the box.