### PR TITLE
Add xpath and jsonpath functions

### DIFF
--- a/examples/rust/jsonpath/Cargo.toml
+++ b/examples/rust/jsonpath/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "jsonpath"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "60e3c5b41e616fee239304d92128e117dd9be0a7" }
+jsonpath_lib = "0.3.0"
+serde_json = "1.0.82"
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/jsonpath/README.md
+++ b/examples/rust/jsonpath/README.md
@@ -1,0 +1,8 @@
+# Compiling
+
+    cargo wasi build --lib
+
+# Cleaning
+
+    cargo clean
+

--- a/examples/rust/jsonpath/jsonpath.wit
+++ b/examples/rust/jsonpath/jsonpath.wit
@@ -1,0 +1,2 @@
+eval-jsonpath: func(json: string, expr: string) -> string
+eval-jsonpaths: func(json: string, expr: string) -> list<string>

--- a/examples/rust/jsonpath/src/lib.rs
+++ b/examples/rust/jsonpath/src/lib.rs
@@ -1,0 +1,23 @@
+wit_bindgen_rust::export!("jsonpath.wit");
+struct Jsonpath;
+
+extern crate jsonpath_lib;
+extern crate serde_json;
+
+impl jsonpath::Jsonpath for Jsonpath {
+    fn eval_jsonpath(json: String, expr: String) -> String {
+        let v = serde_json::from_str(json.as_str()).unwrap();
+        let out = jsonpath_lib::select(&v, expr.as_str()).unwrap();
+        if out.len() > 1 {
+            format!("[{}]", out.into_iter().map(|s| s.to_string()).collect::<Vec<String>>().join(", "))
+        } else {
+            out.into_iter().map(|s| s.to_string()).collect::<String>()
+        }
+    }
+
+    fn eval_jsonpaths(json: String, expr: String) -> Vec<String> {
+        let v = serde_json::from_str(json.as_str()).unwrap();
+        let out = jsonpath_lib::select(&v, expr.as_str()).unwrap();
+        out.into_iter().map(|s| s.to_string()).collect()
+    }
+}

--- a/examples/rust/xpath/Cargo.toml
+++ b/examples/rust/xpath/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xpath"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "60e3c5b41e616fee239304d92128e117dd9be0a7" }
+sxd-xpath = "0.4.2"
+sxd-document = "0.3.2"
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/xpath/README.md
+++ b/examples/rust/xpath/README.md
@@ -1,0 +1,8 @@
+# Compiling
+
+    cargo wasi build --lib
+
+# Cleaning
+
+    cargo clean
+

--- a/examples/rust/xpath/src/lib.rs
+++ b/examples/rust/xpath/src/lib.rs
@@ -1,0 +1,32 @@
+wit_bindgen_rust::export!("xpath.wit");
+struct Xpath;
+
+extern crate sxd_document;
+extern crate sxd_xpath;
+
+use sxd_document::parser;
+use sxd_xpath::evaluate_xpath;
+
+impl xpath::Xpath for Xpath {
+    fn eval_xpath(xml: String, expr: String) -> String {
+        let package = parser::parse(xml.as_str()).expect("failed to parse XML");
+        let document = package.as_document();
+        match evaluate_xpath(&document, expr.as_str()).expect("XPath evaluation failed") {
+            sxd_xpath::Value::Nodeset(v) => {
+                v.into_iter().map(|s| s.string_value()).collect::<Vec<String>>().join("\n")
+            },
+            v => v.string()
+        }
+    }
+
+    fn eval_xpaths(xml: String, expr: String) -> Vec<String> {
+        let package = parser::parse(xml.as_str()).expect("failed to parse XML");
+        let document = package.as_document();
+        match evaluate_xpath(&document, expr.as_str()).expect("XPath evaluation failed") {
+            sxd_xpath::Value::Nodeset(v) => {
+                v.into_iter().map(|s| s.string_value()).collect()
+            },
+            v => vec!(v.string())
+        }
+    }
+}

--- a/examples/rust/xpath/xpath.wit
+++ b/examples/rust/xpath/xpath.wit
@@ -1,0 +1,2 @@
+eval-xpath: func(xml: string, expr: string) -> string
+eval-xpaths: func(xml: string, expr: string) -> list<string>


### PR DESCRIPTION
This PR adds examples that implement XPath and JSONPath functions. There are a total of four functions: 2 UDFs and 2 TVFs. They are:
```
eval_xpath('xml-str', 'xpath-str') -> 'str'
eval_xpaths('xml-str', 'xpath-str') -> list('str')
eval_jsonpath('json-str', 'jsonpath-str') -> 'json-str'
eval_jsonpaths('json-str', 'jsonpath-str') -> list('json-str')
```