### PR TITLE
Examples: s2regex in Rust

### DIFF
--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -18,6 +18,13 @@ Calculate X to the power of Y.
 
 [code](./power/)
 
+## Regex
+
+Capture the first match of a regular expression. This examples demonstrates using thread-local storage to retain state between
+multiple invocations of a UDF.
+
+[code](./regex/)
+
 ## Echo
 
 Echo an input phrase twice.  This example demonstrates using the remote debugging tool.

--- a/examples/rust/jsonpath/Makefile
+++ b/examples/rust/jsonpath/Makefile
@@ -1,0 +1,38 @@
+MODULE := jsonpath
+
+.PHONY: debug
+debug: $(eval TGT:=debug)
+debug: wasm
+
+.PHONY: release
+release: $(eval TGT:=release)
+release: RELFLAGS = --release
+release: wasm
+
+.PHONY: wasm
+wasm:
+	cargo wasi build --lib $(RELFLAGS)
+
+.PHONY: test
+test: debug
+	# Note: Trying to avoid weird string encoding issues here
+	@test "$(writ \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm eval_jsonpath \
+		'{\"firstName\": \"John\"}' "$$.firstName")" = "$(echo John)" \
+    	|| { echo Not equal; exit 2; } \
+    	&& { echo PASS; }
+	writ \
+		--expect '42' \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm eval_jsonpath \
+		'{\"firstName\": \"John\", \"age\": 42}' "$$.age"
+	@echo PASS
+	writ \
+		--expect '' \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm eval_jsonpath \
+		'{\"firstName\": \"John\"}' "$$.lastName"
+	@echo PASS
+
+.PHONY: clean
+clean:
+	@cargo clean
+

--- a/examples/rust/regex/.cargo/config.toml
+++ b/examples/rust/regex/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "wasm32-wasi"
+

--- a/examples/rust/regex/Cargo.toml
+++ b/examples/rust/regex/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "heapregex"
+name = "s2regex"
 version = "0.1.0"
 edition = "2021"
 

--- a/examples/rust/regex/Cargo.toml
+++ b/examples/rust/regex/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "heapregex"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "60e3c5b41e616fee239304d92128e117dd9be0a7" }
+lazy_static = "1.4.0"
+regex = "1.7.0"
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/regex/Makefile
+++ b/examples/rust/regex/Makefile
@@ -1,0 +1,32 @@
+MODULE := sentimentable
+
+.PHONY: debug
+debug: $(eval TGT:=debug)
+debug: wasm
+
+.PHONY: release
+release: $(eval TGT:=release)
+release: RELFLAGS = --release
+release: wasm
+
+.PHONY: wasm
+wasm:
+	cargo wasi build --lib $(RELFLAGS)
+
+.PHONY: test
+test: debug
+	writ \
+	    -e '[{"compound": 0.5573704017131537, "positive": 0.5454545454545455, "negative": 0.0, "neutral": 0.4545454545454546 }]' \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm sentimentable\
+            "it is a fantastic day"
+	@echo PASS
+	writ \
+	    -e '[{"compound": -0.5423261445466404, "positive": 0.0, "negative": 0.5384615384615384, "neutral": 0.46153846153846156 }]' \
+            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm sentimentable\
+            "it is a bad day"
+	@echo PASS
+
+.PHONY: clean
+clean:
+	@cargo clean
+

--- a/examples/rust/regex/Makefile
+++ b/examples/rust/regex/Makefile
@@ -1,4 +1,4 @@
-MODULE := sentimentable
+MODULE := s2regex
 
 .PHONY: debug
 debug: $(eval TGT:=debug)
@@ -16,14 +16,19 @@ wasm:
 .PHONY: test
 test: debug
 	writ \
-	    -e '[{"compound": 0.5573704017131537, "positive": 0.5454545454545455, "negative": 0.0, "neutral": 0.4545454545454546 }]' \
-            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm sentimentable\
-            "it is a fantastic day"
+		--expect '' \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm capture \
+		"empty" "empty"
 	@echo PASS
 	writ \
-	    -e '[{"compound": -0.5423261445466404, "positive": 0.0, "negative": 0.5384615384615384, "neutral": 0.46153846153846156 }]' \
-            --wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm sentimentable\
-            "it is a bad day"
+		--expect b \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm capture \
+		"aabaaabbb" "(b+)"
+	@echo PASS
+	writ \
+		--expect bbb \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm capture \
+		"aabaaabbb" "(b{2,})"
 	@echo PASS
 
 .PHONY: clean

--- a/examples/rust/regex/README.md
+++ b/examples/rust/regex/README.md
@@ -13,16 +13,8 @@ cargo wasi build --lib
 ## Testing with Writ
 
 ```sh
-TODO: change this for regex
-writ --wit sentimentable.wit target/wasm32-wasi/debug/sentimentable.wasm sentimentable 'Wasm is an exciting new technology that we love.'
+writ --wit s2regex.wit target/wasm32-wasi/debug/s2regex.wasm capture "aabaaabbb" "(b{2,})"
 
-[
-  {
-    "compound": 0.812604508328942,
-    "positive": 0.513888888888889,
-    "negative": 0.0,
-    "neutral": 0.4861111111111111
-  }
-]
+"bbb"
 ```
 

--- a/examples/rust/regex/README.md
+++ b/examples/rust/regex/README.md
@@ -1,0 +1,28 @@
+# Regex Capture
+
+This example shows how to create a Wasm UDF that will capture the first regex
+match encountered.  A hash map is used to cache compiled regexes over multiple
+calls so that repeated regexes need not be recompiled every time.
+
+## Build
+
+```sh
+cargo wasi build --lib
+```
+
+## Testing with Writ
+
+```sh
+TODO: change this for regex
+writ --wit sentimentable.wit target/wasm32-wasi/debug/sentimentable.wasm sentimentable 'Wasm is an exciting new technology that we love.'
+
+[
+  {
+    "compound": 0.812604508328942,
+    "positive": 0.513888888888889,
+    "negative": 0.0,
+    "neutral": 0.4861111111111111
+  }
+]
+```
+

--- a/examples/rust/regex/s2regex.wit
+++ b/examples/rust/regex/s2regex.wit
@@ -1,0 +1,1 @@
+capture: func(input: string, pattern: string) -> string

--- a/examples/rust/regex/src/lib.rs
+++ b/examples/rust/regex/src/lib.rs
@@ -1,0 +1,33 @@
+wit_bindgen_rust::export!("s2regex.wit");
+use regex::Regex;
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+struct S2regex;
+
+thread_local! {
+    static COMPILED_RGXS: RefCell<HashMap<String, Regex>> = RefCell::new(HashMap::new());
+}
+
+impl s2regex::S2regex for S2regex {
+    fn capture(input: String, pattern: String) -> String {
+        if !COMPILED_RGXS.with(|c| c.borrow().contains_key(&input)) {
+            let re = Regex::new(pattern.as_str()).unwrap();
+            COMPILED_RGXS.with(|c| c.borrow_mut().insert(pattern.clone(), re));
+        }
+        COMPILED_RGXS.with(|c| {
+            let rgx_map = c.borrow();
+            let re = rgx_map.get(pattern.as_str()).unwrap();
+            match re.captures(&input) {
+                Some(caps) => {
+                    if caps.len() > 1 {
+                        return caps[1].to_string();
+                    }
+                    return "".to_string();
+                }
+                None => "".to_string(),
+            }
+        })
+    }
+}
+


### PR DESCRIPTION
## General

This PR adds a simple `s2regex` example WASM rust crate supporting arbitrary regex matches on an input string.

## Misc

- [X] Add missing `Makefile` & `writ` tests to the `jsonpath` example
