### PR TITLE
unicode normalization example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,7 +32,8 @@ cpp:
 rust-debug: rust
 
 .PHONY: rust-release
-rust-release: REL_FLAGS = --release
+rust-release: TARGET=release
+rust-release: rust
 
 .PHONY: rust
 rust:

--- a/examples/rust/unicode-normalizer/.cargo/config.toml
+++ b/examples/rust/unicode-normalizer/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "wasm32-wasi"
+

--- a/examples/rust/unicode-normalizer/Cargo.toml
+++ b/examples/rust/unicode-normalizer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "unicode_normalizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen.git", rev = "60e3c5b41e616fee239304d92128e117dd9be0a7" }
+unicode-normalization = "0.1.22"
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/unicode-normalizer/Makefile
+++ b/examples/rust/unicode-normalizer/Makefile
@@ -1,0 +1,34 @@
+MODULE := unicode_normalizer
+
+.PHONY: debug
+debug: $(eval TGT:=debug)
+debug: wasm
+
+.PHONY: release
+release: $(eval TGT:=release)
+release: RELFLAGS = --release
+release: wasm
+
+.PHONY: wasm
+wasm:
+	cargo wasi build --lib $(RELFLAGS)
+
+.PHONY: test
+test: debug
+	# the ô character in the following tests are encoded in different ways
+	# to test out normalization
+	writ \
+	    -e "Yôga" \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm normalize-unicode-nfd \
+		"Yôga"
+	@echo PASS
+	writ \
+	    -e "Yôga" \
+		--wit $(MODULE).wit target/wasm32-wasi/debug/$(MODULE).wasm normalize-unicode-nfc \
+		"Yôga"
+	@echo PASS
+
+.PHONY: clean
+clean:
+	@cargo clean
+

--- a/examples/rust/unicode-normalizer/src/lib.rs
+++ b/examples/rust/unicode-normalizer/src/lib.rs
@@ -1,0 +1,14 @@
+wit_bindgen_rust::export!("unicode_normalizer.wit");
+
+use unicode_normalization::UnicodeNormalization;
+
+struct UnicodeNormalizer;
+impl unicode_normalizer::UnicodeNormalizer for UnicodeNormalizer {
+    fn normalize_unicode_nfd(input: String) -> String {
+        input.nfd().collect::<String>()
+    }
+
+    fn normalize_unicode_nfc(input: String) -> String {
+        input.nfc().collect::<String>()
+    }
+}

--- a/examples/rust/unicode-normalizer/unicode_normalizer.wit
+++ b/examples/rust/unicode-normalizer/unicode_normalizer.wit
@@ -1,0 +1,2 @@
+normalize-unicode-nfd: func(input: string) -> string
+normalize-unicode-nfc: func(input: string) -> string


### PR DESCRIPTION
This example uses the [unicode_normalization](https://docs.rs/unicode-normalization/latest/unicode_normalization/) rust crate to define NFD and NFC normalization UDFs. A good overview of unicode normalization as well as the difference between NFD and NFC can be found here: https://towardsdatascience.com/what-on-earth-is-unicode-normalization-56c005c55ad0